### PR TITLE
Correcting the LEFT() example return

### DIFF
--- a/articles/cosmos-db/documentdb-sql-query-reference.md
+++ b/articles/cosmos-db/documentdb-sql-query-reference.md
@@ -2023,7 +2023,7 @@ SELECT LEFT("abc", 1), LEFT("abc", 2)
  Here is the result set.  
   
 ```  
-[{"$1": "ab", "$2": "ab"}]  
+[{"$1": "a", "$2": "ab"}]  
 ```  
   
 ####  <a name="bk_length"></a> LENGTH  


### PR DESCRIPTION
The LEFT example return was returning the wrong number of characters.